### PR TITLE
Feature / Option to Set Data as Always up-to-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,17 @@ The mapping of the attribute names you'd like to use across your codebase with t
 #### `outOfDateAfter` [optional]
 Default: `-1` | Type: `Number`, in milliseconds
 
-Defines when the data will get out of date. In milliseconds. If the data will never get out of date, you can set `outOfDateAfter` to `-1`.
+Defines when the data will get out of date.
+
+- Set to `0` if the data will always be up to date once cached.
+- Set to `-1` if the data will always be outdated when fetched. If so, probably it will make the most sense to store it in a local variable, instead of in the local storage (the default). Like so:
+    ```javascript
+    const WeatherRepository = new SuperRepo({
+        /* ... */
+        storage: 'LOCAL_VARIABLE',
+        outOfDateAfter: 0
+    });
+    ```
 
 #### `mapData` [optional]
 Type: `Function`

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ There are 3 edge cases that prevent network (performance) overhead:
 
 - if `outOfDateAfter` value is not set (default value is `-1`), it will trigger a sync on every 1 second.
 - if `outOfDateAfter` value is `0`, it will trigger a sync on every 1 second.
-- if `outOfDateAfter` value is less than 1000 (1 second), it will trigger a sync on every 1 second instead.
+- if `outOfDateAfter` value is less than `1000` (1 second), it will trigger a sync on every 1 second instead.
 
 #### `.destroySyncer()`
 Returns: `Void`

--- a/README.md
+++ b/README.md
@@ -329,10 +329,8 @@ WeatherRepository.clearData().then( _prevData => {
 #### `.initSyncer()`
 Returns: `Void`
 
-Initiates a setInterval, which will countdown to the point when the data is out of date (based on the `outOfDateAfter` value) and will trigger a server request to get fresh data.
+Initiates a countdown-er to the point when the data gets out of date (based on the `outOfDateAfter` value) and triggers a (network) request to get fresh data.
 
-You might want to set the `outOfDateAfter` value, since otherwise, it will trigger a sync on every 1 second (otherwise, this might be a big network (performance) overhead).
-    
 ```javascript
 const WeatherRepository = new SuperRepo({
     outOfDateAfter: 5 * 60 * 1000 // 5 min
@@ -341,6 +339,12 @@ const WeatherRepository = new SuperRepo({
 
 WeatherRepository.initSyncer();
 ```
+
+There are 3 edge cases that prevent network (performance) overhead:
+
+- if `outOfDateAfter` value is not set (default value is `-1`), it will trigger a sync on every 1 second.
+- if `outOfDateAfter` value is `0`, it will trigger a sync on every 1 second.
+- if `outOfDateAfter` value is less than 1000 (1 second), it will trigger a sync on every 1 second instead.
 
 #### `.destroySyncer()`
 Returns: `Void`

--- a/src/index.js
+++ b/src/index.js
@@ -236,6 +236,14 @@ class SuperRepo {
                         isDataUpToDate: false,
                         localData: _localStore
                     });
+                } else if (outOfDateAfter === 0) {
+                    // Setting the `outOfDateAfter` config to 0
+                    // allows users to mark the data as always up to date
+                    // (only if not invalidated or missing, of course)
+                    _resolve({
+                        isDataUpToDate: true,
+                        localData: _localStore
+                    });
                 } else {
                     const { lastFetched } = _localStore;
                     const isLimitExceeded =

--- a/test/data-sync.js
+++ b/test/data-sync.js
@@ -233,4 +233,35 @@ describe('Data Sync', () => {
             expect(networkRequestsCount).to.equal(13);
         }).then(done, done);
     });
+
+    it('Should initiate a background data sync process on every 1 second when `outOfDateAfter` option is set to 0', done => {
+        let networkRequestsCount = 0;
+
+        const repo = new SuperRepo({
+            storage: 'LOCAL_VARIABLE',
+            name: 'test',
+            outOfDateAfter: 0,
+            request: () => {
+                networkRequestsCount++;
+
+                return new Promise(resolve => resolve({ whatever: true }));
+            }
+        });
+
+        repo.initSyncer().then( () => {
+            expect(networkRequestsCount).to.equal(1);
+
+            clock.tick(500);
+            expect(networkRequestsCount).to.equal(1);
+
+            clock.tick(500);
+            expect(networkRequestsCount).to.equal(2);
+
+            clock.tick(1000);
+            expect(networkRequestsCount).to.equal(3);
+
+            clock.tick(10 * 1000);
+            expect(networkRequestsCount).to.equal(13);
+        }).then(done, done);
+    });
 });


### PR DESCRIPTION
Adds option to set the `outOfDateAfter` config to `0`, which allows users to mark the data as always up to date (only if not invalidated or missing, of course).

Adds notes for the syncer logic and the 3 edge cases that prevent network (performance) overhead.